### PR TITLE
Watch deployment builds and adjust repository actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,4 +58,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: 4.26.0
-          command: versions upload --preview-alias ${{ github.head_ref || github.ref_name }}
+          command: versions upload --preview-alias ${{ steps.branch.outputs.branch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,9 @@ jobs:
       - name: Sanitize branch name
         id: branch
         run: |
-          BRANCH_NAME="${GITHUB_REF_NAME//\//-}"
-          echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+          RAW_NAME="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          SAFE_NAME="${RAW_NAME//\//-}"
+          echo "branch=$SAFE_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to Cloudflare Workers (main)
         if: github.ref_name == 'main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,8 @@ jobs:
         run: |
           RAW_NAME="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
           SAFE_NAME="${RAW_NAME//\//-}"
-          echo "branch=$SAFE_NAME" >> "$GITHUB_OUTPUT"
+          TRIMMED_NAME=$(echo "$SAFE_NAME" | cut -c1-15)
+          echo "branch=$TRIMMED_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to Cloudflare Workers (main)
         if: github.ref_name == 'main'

--- a/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor
+++ b/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor
@@ -6,9 +6,24 @@
 <div class="repository-selector">
 @if (IsFreeVersion)
 {
+    if (currentRepository?.NeedsPrToMerge == false)
+    {
+        <button class="update-link" @onclick="Deploy" disabled="@BuildWatcher.IsUpdating">Deploy</button>
+    }
+    else if (currentRepository?.NeedsPrToMerge == true)
+    {
+        if (string.IsNullOrEmpty(DeploymentRequestUrl))
+        {
+            <button class="update-link" @onclick="RequestDeployment" disabled="@BuildWatcher.IsUpdating">Request Deployment</button>
+        }
+        else
+        {
+            <a class="update-link" href="@DeploymentRequestUrl" target="_blank">View Deployment Request</a>
+        }
+    }
     if (currentRepository?.HasWorkflowDispatch == true)
     {
-        <button class="update-link" @onclick="TriggerUpdate" disabled="@BuildWatcher.IsUpdating">Update Site</button>
+        <button class="update-link" @onclick="TriggerUpdate" disabled="@BuildWatcher.IsUpdating">Update Preview</button>
     }
     <label for="repository-dropdown">Site:</label>
     <select id="repository-dropdown" @onchange="OnRepositoryChanged" value="@GetCurrentRepositoryId()">
@@ -25,27 +40,27 @@
     {
         <a class="preview-link" href="@currentRepository.PreviewUrl" target="_blank">See Preview</a>
     }
-    @if (currentRepository?.NeedsPrToMerge == false)
+}
+else
+{
+    if (currentRepository?.NeedsPrToMerge == false)
     {
-        <button class="update-link" @onclick="Deploy">Deploy</button>
+        <button class="update-link" @onclick="Deploy" disabled="@BuildWatcher.IsUpdating">Deploy</button>
     }
     else if (currentRepository?.NeedsPrToMerge == true)
     {
         if (string.IsNullOrEmpty(DeploymentRequestUrl))
         {
-            <button class="update-link" @onclick="RequestDeployment">Request Deployment</button>
+            <button class="update-link" @onclick="RequestDeployment" disabled="@BuildWatcher.IsUpdating">Request Deployment</button>
         }
         else
         {
             <a class="update-link" href="@DeploymentRequestUrl" target="_blank">View Deployment Request</a>
         }
     }
-}
-else
-{
     if (currentRepository?.HasWorkflowDispatch == true)
     {
-        <button class="update-link" @onclick="TriggerUpdate" disabled="@BuildWatcher.IsUpdating">Update Site</button>
+        <button class="update-link" @onclick="TriggerUpdate" disabled="@BuildWatcher.IsUpdating">Update Preview</button>
     }
     <label for="repository-dropdown">Site:</label>
     <select id="repository-dropdown" @onchange="OnRepositoryChanged" value="@GetCurrentRepositoryId()">
@@ -60,21 +75,6 @@ else
     @if (currentRepository?.PreviewUrl != null)
     {
         <a class="preview-link" href="@currentRepository.PreviewUrl" target="_blank">See Preview</a>
-    }
-    @if (currentRepository?.NeedsPrToMerge == false)
-    {
-        <button class="update-link" @onclick="Deploy">Deploy</button>
-    }
-    else if (currentRepository?.NeedsPrToMerge == true)
-    {
-        if (string.IsNullOrEmpty(DeploymentRequestUrl))
-        {
-            <button class="update-link" @onclick="RequestDeployment">Request Deployment</button>
-        }
-        else
-        {
-            <a class="update-link" href="@DeploymentRequestUrl" target="_blank">View Deployment Request</a>
-        }
     }
 }
 </div>

--- a/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor.cs
+++ b/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components;
 using Omny.Cms.UiRepositories.Models;
 using Omny.Cms.UiRepositories.Services;
 using MudBlazor;
+using System;
 
 namespace Omny.Cms.UiRepositories.Components;
 
@@ -72,13 +73,19 @@ public class RepositorySelectorBase : ComponentBase, IDisposable
         {
             if (BuildWatcher.Status != _lastStatus && !string.IsNullOrEmpty(BuildWatcher.Status))
             {
-                var severity = BuildWatcher.Status switch
+                Severity severity;
+                if (BuildWatcher.Status.EndsWith("Completed", StringComparison.OrdinalIgnoreCase))
                 {
-                    "Update Completed" => Severity.Success,
-                    "Update Failed" => Severity.Error,
-                    "Updating Site" => Severity.Info,
-                    _ => Severity.Info
-                };
+                    severity = Severity.Success;
+                }
+                else if (BuildWatcher.Status.EndsWith("Failed", StringComparison.OrdinalIgnoreCase))
+                {
+                    severity = Severity.Error;
+                }
+                else
+                {
+                    severity = Severity.Info;
+                }
                 Snackbar.Add(BuildWatcher.Status, severity, options =>
                 {
                     if (BuildWatcher.CurrentBuildUrl != null)
@@ -150,6 +157,7 @@ public class RepositorySelectorBase : ComponentBase, IDisposable
     protected async Task Deploy()
     {
         await DeploymentService.MergeAsync();
+        await BuildWatcher.StartWatchingAsync(true, "Deployment");
     }
 
     protected async Task RequestDeployment()

--- a/Omny.Cms.Ui/Repositories/Files/GitHub/IGitHubClientProvider.cs
+++ b/Omny.Cms.Ui/Repositories/Files/GitHub/IGitHubClientProvider.cs
@@ -8,6 +8,7 @@ namespace Omny.Cms.UiRepositories.Files.GitHub
         Task<GitHubClient> GetClientAsync();
         Task<Repository> GetRepositoryAsync();
         Task<string> GetBranchShaAsync(bool refresh = false);
+        Task<string> GetBranchShaAsync(string branch, bool refresh = false);
         Task UpdateCachedBranchShaAsync(string sha);
     }
 }


### PR DESCRIPTION
## Summary
- Watch GitHub workflow builds for deployment branch and surface status via snackbars
- Disable update and deployment actions while builds run and rename update button to "Update Preview"
- Allow GitHub client provider to fetch branch SHAs by name

## Testing
- `dotnet test Omny.Cms.Ui.Tests/Omny.Cms.Ui.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68afc46db758832fba8bad01a44a70bf