### PR TITLE
Use MudBlazor components for UI inputs and build feedback

### DIFF
--- a/Omny.Cms.Ui.Tests/LocalRepoPlaywrightTests.cs
+++ b/Omny.Cms.Ui.Tests/LocalRepoPlaywrightTests.cs
@@ -46,7 +46,10 @@ public class LocalRepoPlaywrightTests
         var browserPage = await browserContext.NewPageAsync();
         await browserPage.GotoAsync("/");
         await browserPage.WaitForSelectorAsync("#app");
-        await browserPage.SelectOptionAsync("#repository-dropdown", new[] { new SelectOptionValue { Label = repoName } });
+        var repoDropdown = browserPage.Locator(".repository-dropdown");
+        await repoDropdown.WaitForAsync();
+        await repoDropdown.ClickAsync();
+        await browserPage.Locator("div.mud-list-item", new() { HasText = repoName }).ClickAsync();
         await browserPage.WaitForLoadStateAsync(LoadState.NetworkIdle);
     }
 
@@ -143,7 +146,10 @@ public class LocalRepoPlaywrightTests
         _currentPage = page;
 
         await page.GotoAsync("/");
-        await page.SelectOptionAsync("#repository-dropdown", new[] { new SelectOptionValue { Label = repoName } });
+        var repoDropdown = page.Locator(".repository-dropdown");
+        await repoDropdown.WaitForAsync();
+        await repoDropdown.ClickAsync();
+        await page.Locator("div.mud-list-item", new() { HasText = repoName }).ClickAsync();
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         
         var loadImageButton = await page.WaitForSelectorAsync("button:has-text('Load Image')");

--- a/Omny.Cms.Ui/Editor/Components/CollectionFieldEditor.razor
+++ b/Omny.Cms.Ui/Editor/Components/CollectionFieldEditor.razor
@@ -1,6 +1,7 @@
 @namespace Omny.Cms.UiEditor.Components
 @inherits CollectionFieldEditorBase
 @using Omny.Cms.Editor
+@using MudBlazor
 
 <div class="collection-field">
     @if (_items is not null)
@@ -16,16 +17,16 @@
                 @{
                     var index = i;
                 }
-                <button type="button" @onclick="(() => Remove(index))">Remove</button>
+                <MudButton ButtonType="ButtonType.Button" OnClick="(() => Remove(index))">Remove</MudButton>
             </div>
         }
         <div class="add-buttons">
             @foreach (var t in _allowed)
             {
                 var plugin = PluginRegistry.GetFieldPlugin(t);
-                <button type="button" class="add-field" @onclick="(() => Add(t))">
+                <MudButton ButtonType="ButtonType.Button" Class="add-field" OnClick="(() => Add(t))">
                     <span class="icon">@plugin.Icon</span> Add @plugin.DisplayName
-                </button>
+                </MudButton>
             }
         </div>
     }

--- a/Omny.Cms.Ui/Layout/MainLayout.razor
+++ b/Omny.Cms.Ui/Layout/MainLayout.razor
@@ -1,6 +1,7 @@
 @namespace Omny.Cms.UiLayout
 @inherits MainLayoutBase
 @using Omny.Cms.UiRepositories.Components
+@using MudBlazor
 <div class="page">
     <!--<div class="sidebar">
         <NavMenu/>
@@ -11,7 +12,7 @@
         <div class="top-row px-4">
             <div class="top-row-content">
                 <RepositorySelector />
-                <button @onclick="Logout">Logout</button>
+                <MudButton OnClick="Logout">Logout</MudButton>
             </div>
         </div>
 

--- a/Omny.Cms.Ui/Layout/NavMenu.razor
+++ b/Omny.Cms.Ui/Layout/NavMenu.razor
@@ -1,12 +1,11 @@
 @namespace Omny.Cms.UiLayout
 @inherits NavMenuBase
+@using MudBlazor
 
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">Omny.Cms.Ui</a>
-        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" OnClick="ToggleNavMenu" />
     </div>
 </div>
 

--- a/Omny.Cms.Ui/Layout/NavMenu.razor.css
+++ b/Omny.Cms.Ui/Layout/NavMenu.razor.css
@@ -1,7 +1,3 @@
-.navbar-toggler {
-    background-color: rgba(255, 255, 255, 0.1);
-}
-
 .top-row {
     height: 3.5rem;
     background-color: rgba(0,0,0,0.4);

--- a/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor
+++ b/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor
@@ -26,7 +26,7 @@
     {
         <MudButton Class="update-link" OnClick="TriggerUpdate" Disabled="@BuildWatcher.IsUpdating">Update Preview</MudButton>
     }
-    <MudSelect T="string" Value="selectedRepositoryId" ValueChanged="OnRepositoryChanged" Label="Site" Disabled="@BuildWatcher.IsUpdating">
+    <MudSelect T="string" Value="selectedRepositoryId" ValueChanged="OnRepositoryChanged" Label="Site" Disabled="@BuildWatcher.IsUpdating" Class="repository-dropdown">
         @if (repositories != null)
         {
             foreach (var repo in repositories)
@@ -62,7 +62,7 @@ else
     {
         <MudButton Class="update-link" OnClick="TriggerUpdate" Disabled="@BuildWatcher.IsUpdating">Update Preview</MudButton>
     }
-    <MudSelect T="string" Value="selectedRepositoryId" ValueChanged="OnRepositoryChanged" Label="Site" Disabled="@BuildWatcher.IsUpdating">
+    <MudSelect T="string" Value="selectedRepositoryId" ValueChanged="OnRepositoryChanged" Label="Site" Disabled="@BuildWatcher.IsUpdating" Class="repository-dropdown">
         @if (repositories != null)
         {
             foreach (var repo in repositories)

--- a/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor
+++ b/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor
@@ -2,79 +2,78 @@
 @inherits RepositorySelectorBase
 @using Omny.Cms.UiRepositories.Models
 @using Omny.Cms.UiRepositories.Services
+@using MudBlazor
 
 <div class="repository-selector">
 @if (IsFreeVersion)
 {
     if (currentRepository?.NeedsPrToMerge == false)
     {
-        <button class="update-link" @onclick="Deploy" disabled="@BuildWatcher.IsUpdating">Deploy</button>
+        <MudButton Class="update-link" OnClick="Deploy" Disabled="@BuildWatcher.IsUpdating">Deploy</MudButton>
     }
     else if (currentRepository?.NeedsPrToMerge == true)
     {
         if (string.IsNullOrEmpty(DeploymentRequestUrl))
         {
-            <button class="update-link" @onclick="RequestDeployment" disabled="@BuildWatcher.IsUpdating">Request Deployment</button>
+            <MudButton Class="update-link" OnClick="RequestDeployment" Disabled="@BuildWatcher.IsUpdating">Request Deployment</MudButton>
         }
         else
         {
-            <a class="update-link" href="@DeploymentRequestUrl" target="_blank">View Deployment Request</a>
+            <MudButton Class="update-link" Href="@DeploymentRequestUrl" Target="_blank">View Deployment Request</MudButton>
         }
     }
     if (currentRepository?.HasWorkflowDispatch == true)
     {
-        <button class="update-link" @onclick="TriggerUpdate" disabled="@BuildWatcher.IsUpdating">Update Preview</button>
+        <MudButton Class="update-link" OnClick="TriggerUpdate" Disabled="@BuildWatcher.IsUpdating">Update Preview</MudButton>
     }
-    <label for="repository-dropdown">Site:</label>
-    <select id="repository-dropdown" @onchange="OnRepositoryChanged" value="@GetCurrentRepositoryId()">
+    <MudSelect T="string" Value="selectedRepositoryId" ValueChanged="OnRepositoryChanged" Label="Site" Disabled="@BuildWatcher.IsUpdating">
         @if (repositories != null)
         {
             foreach (var repo in repositories)
             {
-                <option value="@GetRepositoryId(repo)">@repo.Name</option>
+                <MudSelectItem Value="@GetRepositoryId(repo)">@repo.Name</MudSelectItem>
             }
         }
-    </select>
-    <button class="add-repo" @onclick="OpenAddRepositoryDialogAsync">+</button>
+    </MudSelect>
+    <MudButton Class="add-repo" OnClick="OpenAddRepositoryDialogAsync" Disabled="@BuildWatcher.IsUpdating">+</MudButton>
     @if (currentRepository?.PreviewUrl != null)
     {
-        <a class="preview-link" href="@currentRepository.PreviewUrl" target="_blank">See Preview</a>
+        <MudButton Class="preview-link" Href="@currentRepository.PreviewUrl" Target="_blank">See Preview</MudButton>
     }
 }
 else
 {
     if (currentRepository?.NeedsPrToMerge == false)
     {
-        <button class="update-link" @onclick="Deploy" disabled="@BuildWatcher.IsUpdating">Deploy</button>
+        <MudButton Class="update-link" OnClick="Deploy" Disabled="@BuildWatcher.IsUpdating">Deploy</MudButton>
     }
     else if (currentRepository?.NeedsPrToMerge == true)
     {
         if (string.IsNullOrEmpty(DeploymentRequestUrl))
         {
-            <button class="update-link" @onclick="RequestDeployment" disabled="@BuildWatcher.IsUpdating">Request Deployment</button>
+            <MudButton Class="update-link" OnClick="RequestDeployment" Disabled="@BuildWatcher.IsUpdating">Request Deployment</MudButton>
         }
         else
         {
-            <a class="update-link" href="@DeploymentRequestUrl" target="_blank">View Deployment Request</a>
+            <MudButton Class="update-link" Href="@DeploymentRequestUrl" Target="_blank">View Deployment Request</MudButton>
         }
     }
     if (currentRepository?.HasWorkflowDispatch == true)
     {
-        <button class="update-link" @onclick="TriggerUpdate" disabled="@BuildWatcher.IsUpdating">Update Preview</button>
+        <MudButton Class="update-link" OnClick="TriggerUpdate" Disabled="@BuildWatcher.IsUpdating">Update Preview</MudButton>
     }
-    <label for="repository-dropdown">Site:</label>
-    <select id="repository-dropdown" @onchange="OnRepositoryChanged" value="@GetCurrentRepositoryId()">
+    <MudSelect T="string" Value="selectedRepositoryId" ValueChanged="OnRepositoryChanged" Label="Site" Disabled="@BuildWatcher.IsUpdating">
         @if (repositories != null)
         {
             foreach (var repo in repositories)
             {
-                <option value="@GetRepositoryId(repo)">@repo.Name</option>
+                <MudSelectItem Value="@GetRepositoryId(repo)">@repo.Name</MudSelectItem>
             }
         }
-    </select>
+    </MudSelect>
     @if (currentRepository?.PreviewUrl != null)
     {
-        <a class="preview-link" href="@currentRepository.PreviewUrl" target="_blank">See Preview</a>
+        <MudButton Class="preview-link" Href="@currentRepository.PreviewUrl" Target="_blank">See Preview</MudButton>
     }
 }
 </div>
@@ -84,47 +83,5 @@ else
         display: flex;
         align-items: center;
         gap: 8px;
-    }
-
-    .repository-selector label {
-        font-weight: 500;
-        color: #333;
-    }
-
-    .repository-selector select {
-        padding: 4px 8px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        background-color: white;
-        color: #333;
-        min-width: 200px;
-    }
-
-    .repository-selector select:focus {
-        outline: none;
-        border-color: #007bff;
-        box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
-    }
-
-    .repository-selector .update-link,
-    .repository-selector .preview-link {
-        padding: 4px 8px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        text-decoration: none;
-        color: #333;
-    }
-
-    .repository-selector .add-repo {
-        padding: 4px 8px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        background-color: #f5f5f5;
-        cursor: pointer;
-    }
-
-    .repository-selector .update-link:hover,
-    .repository-selector .preview-link:hover {
-        text-decoration: underline;
     }
 </style>


### PR DESCRIPTION
## Summary
- replace manual buttons, selects, and links with MudBlazor components across the UI
- keep build status snackbars open and launch links in a new tab
- disable repository action buttons during active build jobs

## Testing
- ⚠️ `DOTNET_ROLL_FORWARD=Major dotnet test` *(failed: Restore canceled / tests hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a35da998832f8e0f5a38f2ea0ac2