### PR TITLE
Refine build watcher update handling

### DIFF
--- a/Omny.Cms.Ui/Editor/Pages/Editor.razor.cs
+++ b/Omny.Cms.Ui/Editor/Pages/Editor.razor.cs
@@ -130,7 +130,7 @@ public class EditorBase : ComponentBase, IDisposable
         }
         
         _selectedContentItem = newItem;
-        await BuildWatcher.StartWatchingAsync();
+        await BuildWatcher.StartWatchingAsync(quiet: true);
 
         _isSaving = false;
         StateHasChanged();

--- a/Omny.Cms.Ui/Images/Components/ImageSelector.razor.cs
+++ b/Omny.Cms.Ui/Images/Components/ImageSelector.razor.cs
@@ -69,7 +69,7 @@ public class ImageSelectorBase : ComponentBase
         Uploading = true;
         StateHasChanged();
         await EditorService.UploadImageAsync(name, bytes.ToArray());
-        await BuildWatcher.StartWatchingAsync();
+        await BuildWatcher.StartWatchingAsync(quiet: true);
         MudDialog.Close(DialogResult.Ok(name));
         Uploading = false;
         StateHasChanged();


### PR DESCRIPTION
## Summary
- Add "quiet" mode to build watcher so automatic checks don't disable update preview or show notifications unless a build starts
- Improve update preview status message to "Checking for preview build..."
- Use quiet mode when saving content or uploading images

## Testing
- `dotnet test` *(fails: System.Text.Json.JsonException)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfd238d90832f9fc23637be9b7ed5